### PR TITLE
deprecation updates

### DIFF
--- a/main_pipeline.py
+++ b/main_pipeline.py
@@ -24,7 +24,7 @@ import argparse
 import logging
 import astropy.wcs as wcs
 from astropy.nddata import CCDData
-from photutils import Background2D, MeanBackground
+from photutils.background import Background2D, MeanBackground
 from astropy.stats import SigmaClip
 from astropy.coordinates import SkyCoord
 import importlib

--- a/tel_params/MMIRS.py
+++ b/tel_params/MMIRS.py
@@ -3,7 +3,17 @@ import os
 import astropy
 import datetime
 import numpy as np
-from photutils import make_source_mask, Background2D, MeanBackground
+from photutils.background import Background2D, MeanBackground
+
+use_segm = False
+try:
+    from photutils import make_source_mask
+except ImportError:
+    use_segm=True
+    from astropy.stats import sigma_clipped_stats, SigmaClip
+    from photutils.segmentation import SegmentationImage,detect_sources,detect_threshold
+    from photutils.utils import circular_footprint
+
 from astropy.stats import SigmaClip
 from astropy.io import fits
 from astropy.time import Time
@@ -163,7 +173,16 @@ def process_science(sci_list,fil,amp,binn,red_path,mbias=None,mflat=None,proc=No
         processed_data = ccdproc.ccd_process(red, trim=raw.header['DATASEC'])
         log.info('File proccessed and trimmed.')
         log.info('Cleaning cosmic rays and creating mask.')
-        mask = make_source_mask(processed_data, nsigma=3, npixels=5)
+
+        if not use_segm:
+            mask = make_source_mask(processed_data, nsigma=3, npixels=5)
+        else:
+            sigma_clip = SigmaClip(sigma=3.0, maxiters=10)
+            threshold = detect_threshold(processed_data.data, nsigma=2.0, sigma_clip=sigma_clip)
+            segment_img = detect_sources(processed_data.data, threshold, npixels=5)
+            footprint = circular_footprint(radius=10)
+            mask = segment_img.make_source_mask(footprint=footprint)
+        
         masks.append(mask)
         clean, com_mask = create_mask.create_mask(sci,processed_data,'_mask.fits',static_mask(proc)[0],mask,saturation(red.header),binning(),rdnoise(red.header),cr_clean_sigclip(),cr_clean_sigcfrac(),cr_clean_objlim(),log)
         processed_data.data = clean


### PR DESCRIPTION
Updated photutil imports to pull from photutils.background. This is suggested in a warning when performing the import as is.

Propagated changes from https://github.com/CIERA-Transients/POTPyRI/commit/a7e99eb0b290f087b97cec3f7e127dc454f440e6 in tel_params/LRIS.py to tel_params/MMIRS.py