### PR TITLE
Astrometry.net and aperture photometry fix and deprecation updates

### DIFF
--- a/Find_target_phot_new.py
+++ b/Find_target_phot_new.py
@@ -158,14 +158,14 @@ def find_target_phot(stack, fil, fwhm, zp, zp_err, pixscale, show_phot=False, lo
         w = wcs.WCS(header)  # Parse the WCS keywords in the primary HDU
 
     if ra is not None:
-        coords = np.array([[ra, dec]], np.float)  # Array of coordinates: [[RA, Dec]] in [deg, deg]
+        coords = np.array([[ra, dec]], float)  # Array of coordinates: [[RA, Dec]] in [deg, deg]
         pixel_coords = w.wcs_world2pix(coords, 1)[0]     # Find the pixel coordinates in the image
         x = pixel_coords[0]
         y = pixel_coords[1]
     elif x is not None:
         x-=1
         y-=1
-        coords = np.array([[x, y]], np.float)  # Array of coordinates: [[RA, Dec]] in [deg, deg]
+        coords = np.array([[x, y]], float)  # Array of coordinates: [[RA, Dec]] in [deg, deg]
         pixel_coords = w.wcs_pix2world(coords, 1)[0]     # Find the pixel coordinates in the image
         ra = pixel_coords[0]
         dec = pixel_coords[1]
@@ -219,7 +219,7 @@ def find_target_phot(stack, fil, fwhm, zp, zp_err, pixscale, show_phot=False, lo
 
             if len(new_coords) != 0:
                 x, y = new_coords[0]
-                real_coords = w.wcs_pix2world(np.array([[x, y]], np.float), 1)[0]  # Find the pixel coords in the image
+                real_coords = w.wcs_pix2world(np.array([[x, y]], float), 1)[0]  # Find the pixel coords in the image
                 ra, dec = real_coords[0], real_coords[1]
 
                 radial_profile(data, x, y, 0.2, fwhm, rad=6)        # Radial profile
@@ -252,7 +252,7 @@ def find_target_phot(stack, fil, fwhm, zp, zp_err, pixscale, show_phot=False, lo
             else:
                 print('Centroid calculated position: (%.3f, %.3f)'%(x, y))
 
-            real_coords = w.wcs_pix2world(np.array([[x, y]], np.float), 1)[0]  # Find the pixel coords in the image
+            real_coords = w.wcs_pix2world(np.array([[x, y]], float), 1)[0]  # Find the pixel coords in the image
             ra, dec = real_coords[0], real_coords[1]
 
             radial_profile(data, x, y, 0.2, fwhm, rad=6)        # Radial profile

--- a/main_pipeline.py
+++ b/main_pipeline.py
@@ -451,9 +451,15 @@ def main_pipeline(telescope,data_path,cal_path=None,input_target=None,skip_red=N
 
                         # Update stack[k] with fixed WCS header
                         with fits.open(stack[k].replace('_wcs','')) as hdr:
-                            # old_header = hdr[0].header
+                            header_old = hdr[0].header
                             stack_data = hdr[0].data
                         
+                        # Add important fields back into new header
+                        # GAIN is needed for aperture photometry, add other necessary fields here
+                        fields_to_transfer = ['GAIN']
+                        for field in fields_to_transfer:
+                            header_new[field] = header_old[field]
+
                         wcs_file = stack[k].replace('_wcs','').replace('.fits','_wcs.fits')
                         fits.writeto(wcs_file, stack_data, header_new, overwrite=True)
 

--- a/main_pipeline.py
+++ b/main_pipeline.py
@@ -456,7 +456,10 @@ def main_pipeline(telescope,data_path,cal_path=None,input_target=None,skip_red=N
                         
                         # Add important fields back into new header
                         # GAIN is needed for aperture photometry, add other necessary fields here
-                        fields_to_transfer = ['GAIN']
+                        fields_to_transfer = [
+                            'MJD-OBS', 'TIMFIRST', 'TIMLAST', 'EXPTIME', 
+                            'EXPTOT', 'GAIN', 'RDNOISE', 'NFILES'
+                        ]
                         for field in fields_to_transfer:
                             header_new[field] = header_old[field]
 


### PR DESCRIPTION
The header created by astrometry.net replaces the stacked image's original header. These changes re-add the GAIN field to the new header, which is needed when doing aperture photometry.